### PR TITLE
fix: verify MetaDefender Sandbox TLS certificates

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -61,7 +61,7 @@ repos:
         exclude: "README.md"
   # Central hooks
   - repo: https://github.com/phantomcyber/dev-cicd-tools
-    rev: v2.1.4
+    rev: v2.2.4
     hooks:
       - id: build-docs
         language: python

--- a/LICENSE
+++ b/LICENSE
@@ -186,7 +186,7 @@
       same "printed page" as the copyright notice for easier
       identification within third-party archives.
 
-   Copyright (c) OPSWAT, 2024-2025
+   Copyright (c) OPSWAT, 2024-2026
 
    Licensed under the Apache License, Version 2.0 (the "License");
    you may not use this file except in compliance with the License.

--- a/NOTICE
+++ b/NOTICE
@@ -1,2 +1,2 @@
 Splunk SOAR App: Metadefender Sandbox
-Copyright (c) OPSWAT, 2024-2025
+Copyright (c) OPSWAT, 2024-2026

--- a/README.md
+++ b/README.md
@@ -1,9 +1,9 @@
 # Metadefender Sandbox
 
-Publisher: OPSWAT \
-Connector Version: 1.2.1 \
-Product Vendor: OPSWAT \
-Product Name: MetaDefender Sandbox \
+Publisher: OPSWAT <br>
+Connector Version: 1.2.1 <br>
+Product Vendor: OPSWAT <br>
+Product Name: MetaDefender Sandbox <br>
 Minimum Product Version: 6.2.1
 
 MetaDefender Sandbox (previously known as OPSWAT Filescan Sandbox) is a unique adaptive threat analysis technology, enabling zero-day malware detection and comprehensive Indicator of Compromise (IOC) extraction
@@ -52,23 +52,24 @@ VARIABLE | REQUIRED | TYPE | DESCRIPTION
 **api_key** | required | password | The MetaDefender Sandbox API Key to use for connection |
 **poll_interval** | optional | numeric | Number of seconds to poll for a detonation result (Default: 5, Range: [1:30]) |
 **timeout** | optional | numeric | Request Timeout (Default: 60 seconds, Range: [30:300]) |
+**verify_server_cert** | optional | boolean | Verify the server TLS certificate |
 
 ### Supported Actions
 
-[test connectivity](#action-test-connectivity) - Validate the asset configuration for connectivity using supplied configuration \
-[detonate url](#action-detonate-url) - Retrieve detonation analysis results for URL \
-[detonate file](#action-detonate-file) - Retrieve detonation analysis results for file \
-[search terms](#action-search-terms) - Search for scan reports on MetaDefender Sandbox using parameters specified in the 'query' field \
-[file reputation](#action-file-reputation) - Get the reputation for one given hash (returns with the last 10 MetaDefender Sandbox reports) \
-[ip reputation](#action-ip-reputation) - Get the reputation for one given IP address (returns with the last 10 MetaDefender Sandbox reports) \
-[domain reputation](#action-domain-reputation) - Get the reputation for one given Domain address (returns with the last 10 MetaDefender Sandbox reports) \
+[test connectivity](#action-test-connectivity) - Validate the asset configuration for connectivity using supplied configuration <br>
+[detonate url](#action-detonate-url) - Retrieve detonation analysis results for URL <br>
+[detonate file](#action-detonate-file) - Retrieve detonation analysis results for file <br>
+[search terms](#action-search-terms) - Search for scan reports on MetaDefender Sandbox using parameters specified in the 'query' field <br>
+[file reputation](#action-file-reputation) - Get the reputation for one given hash (returns with the last 10 MetaDefender Sandbox reports) <br>
+[ip reputation](#action-ip-reputation) - Get the reputation for one given IP address (returns with the last 10 MetaDefender Sandbox reports) <br>
+[domain reputation](#action-domain-reputation) - Get the reputation for one given Domain address (returns with the last 10 MetaDefender Sandbox reports) <br>
 [url reputation](#action-url-reputation) - Get the reputation for one given URL address (returns with the last 10 MetaDefender Sandbox reports)
 
 ## action: 'test connectivity'
 
 Validate the asset configuration for connectivity using supplied configuration
 
-Type: **test** \
+Type: **test** <br>
 Read only: **True**
 
 #### Action Parameters
@@ -83,7 +84,7 @@ No Output
 
 Retrieve detonation analysis results for URL
 
-Type: **investigate** \
+Type: **investigate** <br>
 Read only: **True**
 
 Detonate url will send an URL to MetaDefender Sandbox for analysis.
@@ -218,7 +219,7 @@ summary.total_objects_successful | numeric | | 2 |
 
 Retrieve detonation analysis results for file
 
-Type: **investigate** \
+Type: **investigate** <br>
 Read only: **True**
 
 Detonate url will send a file from Vault to MetaDefender Sandbox for analysis.
@@ -353,7 +354,7 @@ summary.total_objects_successful | numeric | | 2 |
 
 Search for scan reports on MetaDefender Sandbox using parameters specified in the 'query' field
 
-Type: **investigate** \
+Type: **investigate** <br>
 Read only: **True**
 
 #### Action Parameters
@@ -416,7 +417,7 @@ summary.total_objects_successful | numeric | | 2 |
 
 Get the reputation for one given hash (returns with the last 10 MetaDefender Sandbox reports)
 
-Type: **investigate** \
+Type: **investigate** <br>
 Read only: **True**
 
 #### Action Parameters
@@ -452,7 +453,7 @@ summary.total_objects_successful | numeric | | 2 |
 
 Get the reputation for one given IP address (returns with the last 10 MetaDefender Sandbox reports)
 
-Type: **investigate** \
+Type: **investigate** <br>
 Read only: **True**
 
 #### Action Parameters
@@ -486,7 +487,7 @@ summary.total_objects_successful | numeric | | 2 |
 
 Get the reputation for one given Domain address (returns with the last 10 MetaDefender Sandbox reports)
 
-Type: **investigate** \
+Type: **investigate** <br>
 Read only: **True**
 
 #### Action Parameters
@@ -520,7 +521,7 @@ summary.total_objects_successful | numeric | | 2 |
 
 Get the reputation for one given URL address (returns with the last 10 MetaDefender Sandbox reports)
 
-Type: **investigate** \
+Type: **investigate** <br>
 Read only: **True**
 
 #### Action Parameters
@@ -554,7 +555,7 @@ ______________________________________________________________________
 
 Auto-generated Splunk SOAR Connector documentation.
 
-Copyright 2025 Splunk Inc.
+Copyright 2026 Splunk Inc.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/__init__.py
+++ b/__init__.py
@@ -1,6 +1,6 @@
 # File: __init__.py
 #
-# Copyright (c) OPSWAT, 2024-2025
+# Copyright (c) OPSWAT, 2024-2026
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/metadefender_sandbox_connector.py
+++ b/metadefender_sandbox_connector.py
@@ -1,6 +1,6 @@
 # File: metadefender_sandbox_connector.py
 #
-# Copyright (c) OPSWAT, 2024-2025
+# Copyright (c) OPSWAT, 2024-2026
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/metadefender_sandbox_connector.py
+++ b/metadefender_sandbox_connector.py
@@ -147,7 +147,7 @@ class MetaDefenderSandboxConnector(BaseConnector):
             r = request_func(
                 url,
                 # auth=(username, password),  # basic authentication
-                verify=config.get("verify_server_cert", False),
+                verify=config.get("verify_server_cert", True),
                 timeout=self._timeout,
                 **kwargs,
             )

--- a/metadefender_sandbox_consts.py
+++ b/metadefender_sandbox_consts.py
@@ -1,6 +1,6 @@
 # File: opswatfilescan_consts.py
 #
-# Copyright (c) OPSWAT, 2024-2025
+# Copyright (c) OPSWAT, 2024-2026
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/metadefendersandbox.json
+++ b/metadefendersandbox.json
@@ -62,6 +62,14 @@
             "order": 3,
             "name": "Timeout",
             "id": 3
+        },
+        "verify_server_cert": {
+            "description": "Verify the server TLS certificate",
+            "data_type": "boolean",
+            "default": true,
+            "order": 4,
+            "name": "Verify Server Certificate",
+            "id": 4
         }
     },
     "actions": [

--- a/metadefendersandbox.json
+++ b/metadefendersandbox.json
@@ -18,7 +18,7 @@
             "name": "Peter Vingelmann"
         }
     ],
-    "license": "Copyright (c) OPSWAT, 2024-2025",
+    "license": "Copyright (c) OPSWAT, 2024-2026",
     "app_version": "1.2.1",
     "utctime_updated": "2023-05-12T18:00:17.655821Z",
     "package_name": "phantom_metadefendersandbox",
@@ -2629,5 +2629,11 @@
             ],
             "versions": "EQ(*)"
         }
-    ]
+    ],
+    "pip39_dependencies": {
+        "wheel": []
+    },
+    "pip313_dependencies": {
+        "wheel": []
+    }
 }

--- a/release_notes/unreleased.md
+++ b/release_notes/unreleased.md
@@ -1,1 +1,3 @@
 **Unreleased**
+
+* Added TLS certificate verification and enabled it by default.


### PR DESCRIPTION
## Summary

- add an asset setting for server TLS certificate verification
- enable certificate verification by default
- refresh generated artifacts with current shared tooling

## Tracking

- [PAPP-38238](https://splunk.atlassian.net/browse/PAPP-38238)
- [PSAAS-30913](https://splunk.atlassian.net/browse/PSAAS-30913)
- Parent epic: [ESPM-5228](https://splunk.atlassian.net/browse/ESPM-5228)

## Validation

- `pre-commit run --all-files`
- Python compile validation

Written by Codex.